### PR TITLE
Rename quicklisp-meta project to quicksys

### DIFF
--- a/quicksys.asd
+++ b/quicksys.asd
@@ -1,7 +1,7 @@
-;;;; ql-meta.asd
+;;;; quicksys.asd
 
-(asdf:defsystem #:ql-meta
-    :description "QL-META tracks multiple Quicklisp distributions"
+(asdf:defsystem #:quicksys
+    :description "QUICKSYS tracks multiple Quicklisp distributions"
     :author "Manoel Vilela & Lucas Vieira"
     :license  "MIT"
     :version "0.1.0"
@@ -12,16 +12,16 @@
     :pathname "src"
     :depends-on (:quicklisp)
     :components ((:file "package")
-                 (:file "ql-meta")))
+                 (:file "quicksys")))
 
-(asdf:defsystem #:ql-meta/test
-  :description "QL-META test suit"
+(asdf:defsystem #:quicksys/test
+  :description "QUICKSYS test suit"
   :author "Manoel Vilela & Lucas Vieira"
   :license  "MIT"
   :version "0.1.0"
   :serial t
   :pathname "t"
-  :depends-on (:ql-meta :prove)
+  :depends-on (:quicksys :prove)
   :components ((:file "test"))
   :perform (asdf:test-op :after (op c)
                          (funcall (intern #.(string :run) :prove) c)))

--- a/run-tests.lisp
+++ b/run-tests.lisp
@@ -3,7 +3,7 @@
   (pushnew (truename (sb-unix:posix-getcwd/))
            ql:*local-project-directories*)
   (ql:register-local-projects)
-  (ql:quickload :ql-meta/test :silent t)
+  (ql:quickload :quicksys/test :silent t)
   (setf prove:*enable-colors* t)
   (if (prove:run "t/test.lisp")
       (sb-ext:exit :code 0)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,12 +1,12 @@
 ;;;; package.lisp
 
-(defpackage #:ql-meta
+(defpackage #:quicksys
   (:use #:cl)
-  (:nicknames :qlm)
+  (:nicknames :qs)
   (:export #:*dists*
-           #:install
+           #:install-dist
            #:installedp
-           #:uninstall
+           #:uninstall-dist
            #:dist-name
            #:dist-url
            #:dist-properties
@@ -17,22 +17,23 @@
            #:dist-apropos-list
            #:quickload)
   (:documentation
-   "QL-META provides a collection of tools to handle multiple quicklisp dists.
+   "QUICKSYS provides a collection of tools to load systems from
+   multiple quicklisp dists.
 
 EXAMPLES
 
 ;; search for a dist
-* (ql-meta:dist-apropos '*)
+* (quicksys:dist-apropos '*)
 #<DIST BODGE / http://bodge.borodust.org/dist/org.borodust.bodge.txt>
 #<DIST CL21 / http://dists.cl21.org/cl21.txt>
 #<DIST ULTRALISP / http://dist.ultralisp.org>
 #<DIST SHIRAKUMO / http://dist.tymoon.eu/shirakumo.txt>
 
 ;; install a dist
-* (ql-meta:install :ultralisp)
+* (quicksys:install :ultralisp)
 
 
 ;; install a dist temporary just to load a system
-* (ql-meta:quickload 'trivial-gamekit :dist 'bodge )
+* (quicksys:quickload 'trivial-gamekit :dist 'bodge )
 "
    ))

--- a/src/quicksys.lisp
+++ b/src/quicksys.lisp
@@ -4,7 +4,7 @@ Manoel Vilela & Lucas Vieira © 2019 MIT
 
 |#
 
-(in-package #:ql-meta)
+(in-package #:quicksys)
 
 
 ;; DIST: alist :: key -> plist
@@ -23,8 +23,8 @@ in QL-META.")
 (defun %dist-id (dist-name)
   "%DIST-ID converts DIST-NAME to an inner key representation."
   (if (typep dist-name 'string)
-      (intern (string-upcase dist-name) :ql-meta)
-      (intern (symbol-name dist-name) :ql-meta)))
+      (intern (string-upcase dist-name) :quicksys)
+      (intern (symbol-name dist-name) :quicksys)))
 
 (defun %dist-realname (dist)
   "%DIST-REALNAME generates the name of a DIST as a downcase string."
@@ -70,8 +70,8 @@ yields NIL."
   (let ((dist-obj (ql-dist:find-dist (%dist-realname dist))))
     (and dist-obj (ql-dist:installedp dist-obj))))
 
-(defun install (dist-name &key (force nil))
-  "INSTALL a dist DIST-NAME using QL-DIST.
+(defun install-dist (dist-name &key (force nil))
+  "INSTALL-DIST a dist DIST-NAME using QL-DIST.
 
 As default, use the parameters (:prompt nil :replace t) on
 ql-dist:install-dist to avoid human interaction.
@@ -87,8 +87,8 @@ raises an error."
                     (cons (dist-url dist)
                           '(:prompt nil :replace t)))))))
 
-(defun uninstall (dist-name)
-  "UNINSTALL a dist DIST-NAME using QL-DIST.
+(defun uninstall-dist (dist-name)
+  "UNINSTALL-DIST a dist DIST-NAME using QL-DIST.
 
 Yields NIL on uninstallation error and when the dist DIST-NAME were not
 installed in the first place. Otherwise, yields T."
@@ -108,10 +108,10 @@ Specifying SILENT suppresses output."
   (let* ((%dist (get-dist dist))
          (installed-before (and %dist (installedp %dist))))
     (when dist
-      (install dist))
+      (install-dist dist))
     (ql:quickload system :silent silent)
     (unless installed-before
-      (uninstall dist))))
+      (uninstall-dist dist))))
 
 
 (defgeneric dist-apropos-list (term)

--- a/t/test.lisp
+++ b/t/test.lisp
@@ -1,13 +1,13 @@
-(defpackage #:ql-meta/test
+(defpackage #:quicksys/test
   (:use #:cl
         #:prove)
-  (:documentation "Collection of unit tests for QL-META"))
+  (:documentation "Collection of unit tests for QUICKSYS"))
 
 
-(in-package :ql-meta/test)
+(in-package :quicksys/test)
 
 
-(setq ql-meta:*dists*
+(setq quicksys:*dists*
   '((test1 (:url "http://test1.com"))
     (test2 (:url "http://test2.com"))))
 
@@ -15,31 +15,31 @@
 
 (diag "== Testing: get-dists-names & get-dists-urls!")
 
-(is (ql-meta:get-dists-names) '(test1 test2)
+(is (quicksys:get-dists-names) '(test1 test2)
     "get-dists-names test 1")
-(is (ql-meta:get-dists-urls) '("http://test1.com"
+(is (quicksys:get-dists-urls) '("http://test1.com"
                                "http://test2.com")
     "get-dists-urls test 1")
 
 (diag "== Testing: get-dist!")
-(ok (typep (ql-meta:get-dist :test1) 'list)
+(ok (typep (quicksys:get-dist :test1) 'list)
     "get-dist keyword")
-(ok (typep (ql-meta:get-dist 'test2) 'list)
+(ok (typep (quicksys:get-dist 'test2) 'list)
     "get-dist symbol")
-(is (ql-meta:get-dist 'test3) nil
+(is (quicksys:get-dist 'test3) nil
     "get-dist symbol invalid")
-(ok (typep (ql-meta:get-dist "test2") 'list)
+(ok (typep (quicksys:get-dist "test2") 'list)
     "get-dist string")
 
 (diag "== Testing: dist-apropos-list!")
 
-(is ql-meta:*dists* (ql-meta:dist-apropos-list '*)
+(is quicksys:*dists* (quicksys:dist-apropos-list '*)
     "dist-apropos-list wildcard *")
-(is ql-meta:*dists* (ql-meta:dist-apropos-list "")
+(is quicksys:*dists* (quicksys:dist-apropos-list "")
     "dist-apropos-list empty string")
-(is 'TEST1 (caar (ql-meta:dist-apropos-list :test1))
+(is 'TEST1 (caar (quicksys:dist-apropos-list :test1))
     "dist-apropos-list name search")
-(is '(TEST1 TEST2) (mapcar #'car (ql-meta:dist-apropos-list ".com"))
+(is '(TEST1 TEST2) (mapcar #'car (quicksys:dist-apropos-list ".com"))
     "dist-apropos-list url search")
 
 (finalize)


### PR DESCRIPTION
Side effects:
+ install get renamed to install-dist
+ uninstall get renamed to uninstall-dist
+ the nickname of the quicksys package is qs.