### PR TITLE
Make docs.lisp more portable

### DIFF
--- a/docs.lisp
+++ b/docs.lisp
@@ -1,6 +1,9 @@
-(ql:quickload :quicksys)
+(pushnew (uiop/os:getcwd) asdf:*central-registry*)
+(ql:register-local-projects)
+(ql:quickload :quicksys :silent t)
 (ql:quickload :staple :silent t)
 
 (staple:generate :quicksys
                  :packages '(#:quicksys))
+
 (sb-ext:exit :code 0)


### PR DESCRIPTION
Pushing the current working directory to asdf:*central-registry* makes
it more reliable to build the documentation if quicksys is not
visible.